### PR TITLE
Update .upptimerc.yml

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -26,10 +26,6 @@ sites:
     check: "tcp-ping"
     url: ftp.ibt.org.ru
     port: 21
-  - name: Xiphos FTP
-    check: "tcp-ping"
-    url: ftp.xiphos.org
-    port: 21
   - name: Step Bible
     url: https://public.modules.stepbible.org
   - name: AndBible Github repo


### PR DESCRIPTION
I propose dropping Xiphos FTP, it is alarming all the time and it is not even used in AndBible